### PR TITLE
Add pre-commit metadata

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: alidistlint
+    name: alidistlint
+    description: Run alidistlint to check recipe and recipe metadata
+    entry: alidistlint
+    language: python
+    files: \.sh$


### PR DESCRIPTION
This just adds metadata so that `alidistlint` can be used with pre-commit and pre-commit.ci.

This complements the already very useful github actions integration for local development.

It can be used as follows:
```yaml
- repo: https://github.com/olantwin/alidistlint
  rev: pre-commit
  hooks:
  - id: alidistlint
    verbose: true  # if you want to also see warnings and notes in the absence of errors
``` 

`rev` and `repo` of course would correspond to the releases and address of this repo, once merged.